### PR TITLE
Fix product dropdown appearing under slider

### DIFF
--- a/app/assets/stylesheets/shared/topbar.scss
+++ b/app/assets/stylesheets/shared/topbar.scss
@@ -73,6 +73,7 @@ html, body{
 
     ul {
       display: none;
+      z-index: 1001;
       background-color: darken($light-blue, 5%);
       position: absolute;
       min-width: 100%;


### PR DESCRIPTION
Increased z index so dropdown menu will appear on top of the image slide
instead of underneath.
